### PR TITLE
refactor: BlocListenableBase to NesteableBlocListener

### DIFF
--- a/packages/flutter_hooks_bloc/lib/src/bloc_listener.dart
+++ b/packages/flutter_hooks_bloc/lib/src/bloc_listener.dart
@@ -3,7 +3,7 @@ import 'flutter_bloc.dart';
 
 import 'package:flutter/widgets.dart';
 
-abstract class BlocListenableBase {
+abstract class NesteableBlocListener {
   void listen();
 
   bool get hasNoChild;
@@ -34,7 +34,7 @@ abstract class BlocListenerBase<C extends Cubit<S>, S>
 }
 
 class BlocListener<C extends Cubit<S>, S> extends BlocListenerBase<C, S>
-    implements BlocListenableBase {
+    implements NesteableBlocListener {
   const BlocListener({
     Key key,
     C cubit,

--- a/packages/flutter_hooks_bloc/lib/src/multi_bloc_listener.dart
+++ b/packages/flutter_hooks_bloc/lib/src/multi_bloc_listener.dart
@@ -73,7 +73,7 @@ class MultiBlocListener extends HookWidget {
         assert(listeners._debugBlocListenerWithNoChild()),
         assert(child != null);
 
-  final List<BlocListenableBase> listeners;
+  final List<NesteableBlocListener> listeners;
   final Widget child;
 
   @override
@@ -83,6 +83,6 @@ class MultiBlocListener extends HookWidget {
   }
 }
 
-extension _DebugBlocListenerWithNoChildX on List<BlocListenableBase> {
+extension _DebugBlocListenerWithNoChildX on List<NesteableBlocListener> {
   bool _debugBlocListenerWithNoChild() => every((it) => it.hasNoChild);
 }


### PR DESCRIPTION
The `BlocListenable` class was removed for only `BlocListener`, then `BlocListenableBase` is renamed to `NesteableBlocListener`