### PR TITLE
fix useBloc documentation: allowRebuild is not a paramenter anymore

### DIFF
--- a/packages/flutter_hooks_bloc/lib/src/bloc_hook.dart
+++ b/packages/flutter_hooks_bloc/lib/src/bloc_hook.dart
@@ -48,7 +48,7 @@ abstract class BlocWidget<C extends Cubit<S>, S> extends HookWidget {
 ///   @override
 ///   Widget build(BuildContext context) {
 ///     // automatically triggers a rebuild of Counter widget
-///     final counterCubit = useBloc<CounterCubit, int>(allowRebuild: true);
+///     final counterCubit = useBloc<CounterCubit, int>();
 ///
 ///     return GestureDetector(
 ///       onTap: () => counterCubit.increment(),


### PR DESCRIPTION
The `useBloc` hook function allows by default and the rebuild is controller by the returned bool of the new `onEmitted` callback. Then, in the documentation must not appear the old parameter `allowRebuild`.