### PR TITLE
Refactor/bloc widget state type only

### DIFF
--- a/packages/flutter_hooks_bloc/lib/src/bloc_builder.dart
+++ b/packages/flutter_hooks_bloc/lib/src/bloc_builder.dart
@@ -52,8 +52,8 @@ import 'package:flutter/widgets.dart';
 ///)
 /// ```
 /// {@endtemplate}
-class BlocBuilder<C extends Cubit<S>, S> extends BlocWidget<C, S>
-    with BuildWhenOnStateEmittedMixin<C, S> {
+class BlocBuilder<C extends Cubit<S>, S> extends BlocWidget<S>
+    with BuildWhenOnStateEmittedMixin<S> {
   const BlocBuilder({
     Key key,
 
@@ -78,12 +78,12 @@ class BlocBuilder<C extends Cubit<S>, S> extends BlocWidget<C, S>
 
   @override
   Widget build(BuildContext context) {
-    final _cubit = use();
+    final _cubit = use<C>();
     return builder(context, _cubit.state);
   }
 }
 
-mixin BuildWhenOnStateEmittedMixin<C extends Cubit<S>, S> on BlocWidget<C, S> {
+mixin BuildWhenOnStateEmittedMixin<S> on BlocWidget<S> {
   BlocBuilderCondition<S> get buildWhen;
 
   @override

--- a/packages/flutter_hooks_bloc/lib/src/bloc_consumer.dart
+++ b/packages/flutter_hooks_bloc/lib/src/bloc_consumer.dart
@@ -61,8 +61,8 @@ import 'package:flutter/widgets.dart';
 /// )
 /// ```
 /// {@endtemplate}
-class BlocConsumer<C extends Cubit<S>, S> extends BlocListenerBase<C, S>
-    with BuildWhenOnStateEmittedMixin<C, S> {
+class BlocConsumer<C extends Cubit<S>, S> extends BlocListenerBase<S>
+    with BuildWhenOnStateEmittedMixin<S> {
   const BlocConsumer({
     Key key,
 

--- a/packages/flutter_hooks_bloc/lib/src/bloc_hook.dart
+++ b/packages/flutter_hooks_bloc/lib/src/bloc_hook.dart
@@ -62,8 +62,11 @@ abstract class BlocWidget<S> extends HookWidget {
 /// See also:
 ///
 ///  * [Cubit]
-C useBloc<C extends Cubit<S>, S>({C cubit, BlocHookListener<S> onEmitted}) =>
-    use(_BlocHook<C, S>(cubit, onEmitted));
+C useBloc<C extends Cubit<S>, S>({C cubit, BlocHookListener<S> onEmitted}) {
+  final context = useContext();
+  final _cubit = cubit ?? context.bloc<C>();
+  return use(_BlocHook<C, S>(_cubit, onEmitted));
+}
 
 class _BlocHook<C extends Cubit<S>, S> extends Hook<C> {
   const _BlocHook(this.cubit, this.onEmitted);
@@ -90,7 +93,7 @@ class _BlocHookState<C extends Cubit<S>, S>
   @override
   void initHook() {
     super.initHook();
-    _cubit = hook.cubit ?? context.bloc<C>();
+    _cubit = hook.cubit;
     _previous = _cubit?.state;
     _subscribe();
   }
@@ -98,7 +101,7 @@ class _BlocHookState<C extends Cubit<S>, S>
   @override
   void didUpdateHook(_BlocHook<C, S> oldWidget) {
     super.didUpdateHook(oldWidget);
-    final oldCubit = oldWidget.cubit ?? context.bloc<C>();
+    final oldCubit = oldWidget.cubit;
     final currentCubit = hook.cubit ?? oldCubit;
     if (oldCubit != currentCubit) {
       if (_subscription != null) {

--- a/packages/flutter_hooks_bloc/lib/src/bloc_hook.dart
+++ b/packages/flutter_hooks_bloc/lib/src/bloc_hook.dart
@@ -85,16 +85,13 @@ class _BlocHookState<C extends Cubit<S>, S>
   /// Previous state from cubit
   S _previous;
 
-  C _cubit;
-
   @override
-  C build(BuildContext context) => _cubit;
+  C build(BuildContext context) => hook.cubit;
 
   @override
   void initHook() {
     super.initHook();
-    _cubit = hook.cubit;
-    _previous = _cubit?.state;
+    _previous = hook.cubit.state;
     _subscribe();
   }
 
@@ -106,8 +103,7 @@ class _BlocHookState<C extends Cubit<S>, S>
     if (oldCubit != currentCubit) {
       if (_subscription != null) {
         _unsubscribe();
-        _cubit = hook.cubit ?? context.bloc<C>();
-        _previous = _cubit?.state;
+        _previous = hook.cubit.state;
       }
       _subscribe();
     }
@@ -120,14 +116,12 @@ class _BlocHookState<C extends Cubit<S>, S>
   }
 
   void _subscribe() {
-    if (_cubit != null) {
-      _subscription = _cubit.listen((state) {
-        if (hook.onEmitted?.call(context, _previous, state) ?? true) {
-          setState(() {});
-        }
-        _previous = state;
-      });
-    }
+    _subscription = hook.cubit.listen((state) {
+      if (hook.onEmitted?.call(context, _previous, state) ?? true) {
+        setState(() {});
+      }
+      _previous = state;
+    });
   }
 
   void _unsubscribe() {

--- a/packages/flutter_hooks_bloc/lib/src/bloc_hook.dart
+++ b/packages/flutter_hooks_bloc/lib/src/bloc_hook.dart
@@ -15,12 +15,13 @@ typedef BlocHookListener<S> = bool Function(
   S current,
 );
 
-abstract class BlocWidget<C extends Cubit<S>, S> extends HookWidget {
+abstract class BlocWidget<S> extends HookWidget {
   const BlocWidget({Key key, this.cubit}) : super(key: key);
 
-  final C cubit;
+  final Cubit<S> cubit;
 
-  C use() => useBloc<C, S>(cubit: cubit, onEmitted: onStateEmitted);
+  C use<C extends Cubit<S>>() =>
+      useBloc<C, S>(cubit: cubit, onEmitted: onStateEmitted);
 
   @protected
   @mustCallSuper

--- a/packages/flutter_hooks_bloc/lib/src/bloc_hook.dart
+++ b/packages/flutter_hooks_bloc/lib/src/bloc_hook.dart
@@ -20,6 +20,7 @@ abstract class BlocWidget<S> extends HookWidget {
 
   final Cubit<S> cubit;
 
+  @protected
   C use<C extends Cubit<S>>() =>
       useBloc<C, S>(cubit: cubit, onEmitted: onStateEmitted);
 

--- a/packages/flutter_hooks_bloc/lib/src/bloc_hook.dart
+++ b/packages/flutter_hooks_bloc/lib/src/bloc_hook.dart
@@ -65,28 +65,27 @@ abstract class BlocWidget<S> extends HookWidget {
 C useBloc<C extends Cubit<S>, S>({C cubit, BlocHookListener<S> onEmitted}) {
   final context = useContext();
   final _cubit = cubit ?? context.bloc<C>();
-  return use(_BlocHook<C, S>(_cubit, onEmitted));
+  return use(_BlocHook<S>(_cubit, onEmitted)) as C;
 }
 
-class _BlocHook<C extends Cubit<S>, S> extends Hook<C> {
+class _BlocHook<S> extends Hook<Cubit<S>> {
   const _BlocHook(this.cubit, this.onEmitted);
 
-  final C cubit;
+  final Cubit<S> cubit;
   final BlocHookListener<S> onEmitted;
 
   @override
-  HookState<C, Hook<C>> createState() => _BlocHookState<C, S>();
+  HookState<Cubit<S>, _BlocHook<S>> createState() => _BlocHookState<S>();
 }
 
-class _BlocHookState<C extends Cubit<S>, S>
-    extends HookState<C, _BlocHook<C, S>> {
+class _BlocHookState<S> extends HookState<Cubit<S>, _BlocHook<S>> {
   StreamSubscription<S> _subscription;
 
   /// Previous state from cubit
   S _previous;
 
   @override
-  C build(BuildContext context) => hook.cubit;
+  Cubit<S> build(BuildContext context) => hook.cubit;
 
   @override
   void initHook() {
@@ -96,7 +95,7 @@ class _BlocHookState<C extends Cubit<S>, S>
   }
 
   @override
-  void didUpdateHook(_BlocHook<C, S> oldWidget) {
+  void didUpdateHook(_BlocHook<S> oldWidget) {
     super.didUpdateHook(oldWidget);
     final oldCubit = oldWidget.cubit;
     final currentCubit = hook.cubit ?? oldCubit;

--- a/packages/flutter_hooks_bloc/lib/src/bloc_listener.dart
+++ b/packages/flutter_hooks_bloc/lib/src/bloc_listener.dart
@@ -12,10 +12,13 @@ abstract class NesteableBlocListener {
   DiagnosticsNode asDiagnosticsNode();
 }
 
-abstract class BlocListenerBase<C extends Cubit<S>, S>
-    extends BlocWidget<C, S> {
-  const BlocListenerBase({Key key, C cubit, this.listenWhen, this.listener})
-      : super(key: key, cubit: cubit);
+abstract class BlocListenerBase<S> extends BlocWidget<S> {
+  const BlocListenerBase({
+    Key key,
+    Cubit<S> cubit,
+    this.listenWhen,
+    this.listener,
+  }) : super(key: key, cubit: cubit);
 
   /// Takes the previous `state` and the current `state` and is responsible for
   /// returning a [bool] which determines whether or not to call [listener]
@@ -36,7 +39,7 @@ abstract class BlocListenerBase<C extends Cubit<S>, S>
   }
 }
 
-class BlocListener<C extends Cubit<S>, S> extends BlocListenerBase<C, S>
+class BlocListener<C extends Cubit<S>, S> extends BlocListenerBase<S>
     implements NesteableBlocListener {
   const BlocListener({
     Key key,
@@ -52,13 +55,13 @@ class BlocListener<C extends Cubit<S>, S> extends BlocListenerBase<C, S>
 
   @override
   Widget build(BuildContext context) {
-    use();
+    use<C>();
     return child;
   }
 
   /// Helps to subscribe to a [cubit]
   @override
-  void listen() => use();
+  void listen() => use<C>();
 
   @override
   bool get hasNoChild => child == null;


### PR DESCRIPTION
Simplification of generic classes \<C extends Cubit\<S>,S>  to \<S> as much as possible