### PR TITLE
Fix bloc provider refresh

### DIFF
--- a/packages/riverbloc/example/pubspec.yaml
+++ b/packages/riverbloc/example/pubspec.yaml
@@ -11,7 +11,6 @@ dependencies:
     sdk: flutter
 
   cupertino_icons: ^0.1.3
-  riverpod: ^0.7.0
   flutter_riverpod: ^0.7.2
   riverbloc:
     path: ../

--- a/packages/riverbloc/lib/src/bloc_provider.dart
+++ b/packages/riverbloc/lib/src/bloc_provider.dart
@@ -119,7 +119,7 @@ class _BlocStateProviderState<S> extends ProviderStateBase<Cubit<S>, S> {
 
   void _subscribe() {
     if (createdValue != null) {
-      exposedValue ??= createdValue.state;
+      exposedValue = createdValue.state;
       _subscription = createdValue.listen(_listener);
     }
   }

--- a/packages/riverbloc/pubspec.lock
+++ b/packages/riverbloc/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       name: bloc
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.2"
+    version: "6.0.3"
   boolean_selector:
     dependency: transitive
     description:
@@ -164,7 +164,7 @@ packages:
       name: riverpod
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.0"
+    version: "0.8.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/packages/riverbloc/pubspec.yaml
+++ b/packages/riverbloc/pubspec.yaml
@@ -1,7 +1,7 @@
 name: riverbloc
 description: >-
   BlocProvider implementation with riverpod as alternative to provider
-version: 0.0.1
+version: 0.0.1+1
 homepage: https://github.com/kranfix/riverbloc/tree/master/packages/riverbloc
 repository: https://github.com/kranfix/riverbloc
 
@@ -12,8 +12,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  riverpod: ^0.7.0
-  bloc: ^6.0.2
+  riverpod: ^0.8.0
+  bloc: ^6.0.3
 
 dev_dependencies:
   flutter_test:

--- a/packages/riverbloc/test/riverbloc_test.dart
+++ b/packages/riverbloc/test/riverbloc_test.dart
@@ -40,4 +40,25 @@ void main() {
       expect(container.read(counterProvider.state), count + 1);
     }
   });
+
+  test('bloc resubscribe', () async {
+    final container = ProviderContainer();
+    final counterCubit = container.read(counterProvider);
+
+    expect(counterCubit.state, 0);
+    expect(container.read(counterProvider.state), 0);
+
+    for (var i = 0; i < 2; i++) {
+      counterCubit.increment();
+      await Future.value();
+    }
+    expect(container.read(counterProvider.state), 2);
+
+    final counterCubit2 = container.refresh(counterProvider);
+    expect(counterCubit2, isNot(equals(counterCubit)));
+    expect(container.read(counterProvider), equals(counterCubit2));
+
+    expect(counterCubit2.state, 0);
+    expect(container.read(counterProvider.state), 0);
+  });
 }


### PR DESCRIPTION
watch(blocProvider.state) rebuilds a widget when the `cubit/bloc` is recreated.