### PR TITLE
Bloc consumer river test

### DIFF
--- a/packages/flutter_hooks_bloc/lib/src/bloc_consumer.dart
+++ b/packages/flutter_hooks_bloc/lib/src/bloc_consumer.dart
@@ -1,6 +1,7 @@
 import 'bloc_listener.dart';
 import 'bloc_builder.dart';
-import 'flutter_bloc.dart';
+import 'package:bloc/bloc.dart';
+import 'package:riverbloc/riverbloc.dart';
 
 import 'package:flutter/widgets.dart';
 
@@ -78,6 +79,23 @@ class BlocConsumer<C extends Cubit<S>, S> extends BlocListenerBase<C, S> {
         super(
           key: key,
           cubit: cubit,
+          listenWhen: listenWhen,
+          listener: listener,
+        );
+
+  const BlocConsumer.river({
+    Key key,
+    @required BlocProvider<C> provider,
+    BlocListenerCondition<S> listenWhen,
+    @required BlocWidgetListener<S> listener,
+    this.buildWhen,
+    @required this.builder,
+  })  : assert(provider != null),
+        assert(listener != null),
+        assert(builder != null),
+        super.river(
+          key: key,
+          provider: provider,
           listenWhen: listenWhen,
           listener: listener,
         );

--- a/packages/flutter_hooks_bloc/test/bloc_consumer_river_test.dart
+++ b/packages/flutter_hooks_bloc/test/bloc_consumer_river_test.dart
@@ -9,6 +9,8 @@ class CounterCubit extends Cubit<int> {
   void increment() => emit(state + 1);
 }
 
+final counterProvider = BlocProvider((ref) => CounterCubit());
+
 void main() {
   group('BlocConsumer.river', () {
     testWidgets('throws AssertionError if provider is null', (tester) async {
@@ -26,12 +28,25 @@ void main() {
     });
 
     testWidgets('throws AssertionError if listener is null', (tester) async {
-      final counterProvider = BlocProvider((ref) => CounterCubit());
       try {
         await tester.pumpWidget(
           BlocConsumer<CounterCubit, int>.river(
             provider: counterProvider,
             listener: null,
+            builder: null,
+          ),
+        );
+      } on dynamic catch (error) {
+        expect(error, isAssertionError);
+      }
+    });
+
+    testWidgets('throws AssertionError if builder is null', (tester) async {
+      try {
+        await tester.pumpWidget(
+          BlocConsumer<CounterCubit, int>.river(
+            provider: counterProvider,
+            listener: (_, __) {},
             builder: null,
           ),
         );

--- a/packages/flutter_hooks_bloc/test/bloc_consumer_river_test.dart
+++ b/packages/flutter_hooks_bloc/test/bloc_consumer_river_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_hooks_bloc/flutter_hooks_bloc.dart' hide BlocProvider;
+import 'package:riverbloc/riverbloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class CounterCubit extends Cubit<int> {
+  CounterCubit() : super(0);
+
+  void increment() => emit(state + 1);
+}
+
+void main() {
+  group('BlocConsumer.river', () {
+    testWidgets('throws AssertionError if provider is null', (tester) async {
+      try {
+        await tester.pumpWidget(
+          BlocConsumer<CounterCubit, int>.river(
+            provider: null,
+            listener: null,
+            builder: null,
+          ),
+        );
+      } on dynamic catch (error) {
+        expect(error, isAssertionError);
+      }
+    });
+  });
+}

--- a/packages/flutter_hooks_bloc/test/bloc_consumer_river_test.dart
+++ b/packages/flutter_hooks_bloc/test/bloc_consumer_river_test.dart
@@ -82,5 +82,36 @@ void main() {
       expect(find.text('State: 0'), findsOneWidget);
       expect(listenerStates, isEmpty);
     });
+
+    testWidgets(
+        'accesses the bloc directly '
+        'and passes multiple states to builder and listener', (tester) async {
+      final counterCubit = CounterCubit();
+      final counterProvider = BlocProvider((ref) => counterCubit);
+      final listenerStates = <int>[];
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: BlocConsumer<CounterCubit, int>.river(
+                provider: counterProvider,
+                builder: (context, state) {
+                  return Text('State: $state');
+                },
+                listener: (_, state) {
+                  listenerStates.add(state);
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+      expect(find.text('State: 0'), findsOneWidget);
+      expect(listenerStates, isEmpty);
+      counterCubit.increment();
+      await tester.pump();
+      expect(find.text('State: 1'), findsOneWidget);
+      expect(listenerStates, [1]);
+    });
   });
 }

--- a/packages/flutter_hooks_bloc/test/bloc_consumer_river_test.dart
+++ b/packages/flutter_hooks_bloc/test/bloc_consumer_river_test.dart
@@ -1,5 +1,6 @@
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_hooks_bloc/flutter_hooks_bloc.dart' hide BlocProvider;
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverbloc/riverbloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -53,6 +54,33 @@ void main() {
       } on dynamic catch (error) {
         expect(error, isAssertionError);
       }
+    });
+
+    testWidgets(
+        'accesses the bloc directly and passes initial state to builder and '
+        'nothing to listener', (tester) async {
+      final counterCubit = CounterCubit();
+      final counterProvider = BlocProvider((ref) => counterCubit);
+      final listenerStates = <int>[];
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: BlocConsumer<CounterCubit, int>.river(
+                provider: counterProvider,
+                builder: (context, state) {
+                  return Text('State: $state');
+                },
+                listener: (_, state) {
+                  listenerStates.add(state);
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+      expect(find.text('State: 0'), findsOneWidget);
+      expect(listenerStates, isEmpty);
     });
   });
 }

--- a/packages/flutter_hooks_bloc/test/bloc_consumer_river_test.dart
+++ b/packages/flutter_hooks_bloc/test/bloc_consumer_river_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/widgets.dart';
 import 'package:flutter_hooks_bloc/flutter_hooks_bloc.dart' hide BlocProvider;
 import 'package:riverbloc/riverbloc.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -15,6 +16,21 @@ void main() {
         await tester.pumpWidget(
           BlocConsumer<CounterCubit, int>.river(
             provider: null,
+            listener: null,
+            builder: null,
+          ),
+        );
+      } on dynamic catch (error) {
+        expect(error, isAssertionError);
+      }
+    });
+
+    testWidgets('throws AssertionError if listener is null', (tester) async {
+      final counterProvider = BlocProvider((ref) => CounterCubit());
+      try {
+        await tester.pumpWidget(
+          BlocConsumer<CounterCubit, int>.river(
+            provider: counterProvider,
             listener: null,
             builder: null,
           ),


### PR DESCRIPTION
`BlocConsumer.river()` for working with riverbloc and its tests.