### PR TITLE
Add specific entrypoint for usage with Riverbloc / Riverpod (WIP)

### DIFF
--- a/packages/flutter_hooks_bloc/lib/flutter_hooks_riverbloc.dart
+++ b/packages/flutter_hooks_bloc/lib/flutter_hooks_riverbloc.dart
@@ -1,0 +1,7 @@
+library flutter_hooks_bloc;
+
+export 'src/bloc_hook.dart' show useRiverBloc;
+export 'src/bloc_builder.dart';
+export 'src/bloc_listener.dart' show BlocListener, BlocWidgetListener, BlocListenerCondition;
+export 'src/bloc_consumer.dart';
+export 'src/multi_bloc_listener.dart';

--- a/packages/flutter_hooks_bloc/lib/src/bloc_builder.dart
+++ b/packages/flutter_hooks_bloc/lib/src/bloc_builder.dart
@@ -1,5 +1,6 @@
+import 'package:bloc/bloc.dart';
+
 import 'bloc_hook.dart';
-import 'flutter_bloc.dart' hide BlocProvider;
 import 'package:riverbloc/riverbloc.dart' show BlocProvider;
 import 'package:flutter/widgets.dart';
 

--- a/packages/flutter_hooks_bloc/lib/src/bloc_hook.dart
+++ b/packages/flutter_hooks_bloc/lib/src/bloc_hook.dart
@@ -1,8 +1,9 @@
 import 'dart:async';
+import 'package:bloc/bloc.dart';
 import 'package:flutter/foundation.dart';
-import 'package:riverbloc/riverbloc.dart' show BlocProvider;
 
-import 'flutter_bloc.dart' show Cubit, BlocProviderExtension;
+import 'flutter_bloc.dart' show BlocProviderExtension;
+import 'package:riverbloc/riverbloc.dart' show BlocProvider;
 
 import 'package:flutter/widgets.dart' show BuildContext;
 import 'package:flutter_hooks/flutter_hooks.dart';

--- a/packages/flutter_hooks_bloc/lib/src/bloc_listener.dart
+++ b/packages/flutter_hooks_bloc/lib/src/bloc_listener.dart
@@ -1,5 +1,7 @@
+import 'package:bloc/bloc.dart';
+
 import 'bloc_hook.dart';
-import 'flutter_bloc.dart' hide BlocProvider;
+
 import 'package:riverbloc/riverbloc.dart' show BlocProvider;
 
 import 'package:flutter/widgets.dart';
@@ -82,8 +84,7 @@ typedef BlocListenerCondition<S> = bool Function(S previous, S current);
 /// )
 /// ```
 /// {@endtemplate}
-class BlocListener<C extends Cubit<S>, S> extends BlocListenerBase<C, S>
-    implements NesteableBlocListener {
+class BlocListener<C extends Cubit<S>, S> extends BlocListenerBase<C, S> implements NesteableBlocListener {
   const BlocListener({
     Key key,
     C cubit,


### PR DESCRIPTION
This library entrypoint does not explicitly import flutter_bloc or its hook and therefore its BuildContext extensions that compete with riverpod's ones.

TODO:
- [ ] Decide if we want to remove 'useRiverBloc` from the export list in the existing entrypoint (Breaking change)
- [ ] Add documentation for the new entrypoint

Fixes #35