### PR TITLE
Update README To Reflect Project Goals

### DIFF
--- a/packages/riverbloc/README.md
+++ b/packages/riverbloc/README.md
@@ -2,9 +2,7 @@
 
 ![Banner](https://raw.githubusercontent.com/kranfix/riverbloc/master/resources/riverbloc_banner.png)
 
-An implementation of `BlocProvider` based on #[riverpod](https://pub.dev/packages/riverpod) providers.
-The goal of this package is to make easy the migration from `flutter_bloc` to
-`flutter_riverpod`.
+An implementation of the [BLoC](https://pub.dev/packages/bloc) pattern based on [riverpod](https://pub.dev/packages/riverpod).
 
 If you are interested in `hooks` with `bloc`, see also
 [flutter_hooks_bloc](https://pub.dev/packages/flutter_hooks_bloc)


### PR DESCRIPTION
I recently came across this package and am currently using it in my own project and loving it. But I almost did not even consider this package because of this statement. To me this reads "The goal of this package is to be a transitional dependency until you have entirely converted to using `flutter_riverpod`". I don't believe this is entirely accurate. This project to me seems standalone. And even the threads I found on the subject seem to indicate so https://github.com/felangel/bloc/issues/2100 .