### PR TITLE
flutter_hooks_bloc v0.18.0

### DIFF
--- a/packages/flutter_hooks_bloc/CHANGELOG.md
+++ b/packages/flutter_hooks_bloc/CHANGELOG.md
@@ -1,4 +1,16 @@
-## [0.17.0] - 2021-11-26
+## [0.18.0] - 2026-04-05
+
+- Upgraded dependencies: `bloc` ^9.2.0, `flutter_bloc` ^9.1.1,
+  `flutter_hooks` ^0.21.3+1, `very_good_analysis` ^10.0.0
+- Fix: `BlocListener` without a `child` no longer throws — renders
+  `Offstage()` instead
+- New: `debugFillProperties` implemented on `BlocBuilder`, `BlocListener`
+  and `BlocConsumer`, matching the `flutter_bloc` original
+- Fix: `_BlocHookState._unsubscribe` now uses the `unawaited` pattern
+- Lint fixes across the test suite
+- Documentation improvements: README rewritten, dartdoc comments corrected
+
+## [0.17.0] - 2023-11-26
 
 - Upgraded bloc to 8.1.3
 - Upgraded flutter_hooks to 0.20.3
@@ -41,7 +53,7 @@
 
 - Upgrading to null-safety
 
-## [0.11.0]
+## [0.11.0] - 2020-09-07
 
 - Adding `userRiverBloc()` hook function.
 - Adding contructors for using riverbloc with the bloc widgets:
@@ -53,24 +65,24 @@
   import 'package:flutter_hooks_bloc/flutter_riverbloc.dart';
   ```
 
-## [0.10.0]
+## [0.10.0] - 2020-08-30
 
 - Adding documentation for a imaginary `MultiBlocBuilder`.
 - Refactor class templates to depends on state runtimeType.
 - Protecting HookWidget.use()
 
-## [0.9.0]
+## [0.9.0] - 2020-08-28
 
 - Renaming `BlocListenableBase` to `NesteableBlocListener`.
 - `BlocListener` is has `debugFillProperties`.
 - `MultiBlocListener` is has `debugFillProperties`.
 - Fix in `useBloc` documentation.
 
-## [0.8.0]
+## [0.8.0] - 2020-08-24
 
 - `useBloc` use `onEmitted` instead `listener` and `buildWhen`
 
-## [0.7.0]
+## [0.7.0] - 2020-08-23
 
 - Removing BlocListenable in favor of only BlocListener
 - Removing CubitComposer in favor of BlocWidget
@@ -78,13 +90,13 @@
 - `flutter_hooks` dependency updated
 - `useBloc` rebuilds `HookWidget` by default
 
-## [0.6.0]
+## [0.6.0] - 2020-08-22
 
 - Unexporting `flutter_hooks` by default
 - Removing BlocBuilderInterface
 - Fixing useBloc description in README
 
-## [0.5.0]
+## [0.5.0] - 2020-08-22
 
 - Some documentation added
 - Refactor for reducing the quantity of mixins and extensions
@@ -92,7 +104,7 @@
 - Optimization in check if all `BlocListener`s have no child
   in a `MultiBlocListener`
 
-## [0.4.0]
+## [0.4.0] - 2020-08-21
 
 - useBloc
 - BlocConsumer

--- a/packages/flutter_hooks_bloc/README.md
+++ b/packages/flutter_hooks_bloc/README.md
@@ -2,7 +2,7 @@
 
 ![Coverage](https://raw.githubusercontent.com/kranfix/riverbloc/master/packages/flutter_hooks_bloc/coverage_badge.svg?sanitize=true)
 
-A flutter_bloc reimplementation based on flutter_hooks for
+A `flutter_bloc` reimplementation based on `flutter_hooks` for
 `BlocBuilder`, `BlocListener`, `BlocConsumer` and `MultiBlocListener`.
 
 ## Usage as flutter_bloc
@@ -12,115 +12,94 @@ A flutter_bloc reimplementation based on flutter_hooks for
 They work exactly the same as the original. See the `flutter_bloc`
 [documentation](https://bloclibrary.dev/#/flutterbloccoreconcepts).
 
-**useBloc**
+## useBloc
 
-The `useBloc` hook function allows to listen state changes and rebuild
-the widget if necessary.
+The `useBloc` hook allows listening to state changes and optionally
+rebuilding the widget.
 
 ```dart
+// BlocHookListener<S> = bool Function(BuildContext context, S previous, S current)
+
 S useBloc<B extends StateStreamable<S>, S>({
-  /// bloc or cubit to subscribe. if it is null, it will be infered
+  /// Bloc or cubit to subscribe to. If null, it is inferred from
+  /// the current BuildContext.
   B? bloc,
 
-  /// If `onEmitted` is not provided or its invocation returns `true`,
-  /// the widget will rebuild.
+  /// Called on every state emission. Return true to trigger a rebuild,
+  /// false to behave like a listener only.
   BlocHookListener<S>? onEmitted,
 });
 ```
 
-It can be used into a HookBuilder:
+It can be used inside a `HookBuilder`:
 
 ```dart
-HookBuilder(builder: (ctx) {
-  print('HookBuilder');
-  final counter = useBloc<CounterCubit, int>(
-    onEmitted: (_, prev, curr) {
-      print('listener: $prev $curr');
-      return true;
-    }
-  );
-  return Text(
-    '$counter',
-    style: Theme.of(context).textTheme.headline4,
-  );
-});
+HookBuilder(
+  builder: (context) {
+    final counter = useBloc<CounterCubit, int>(
+      onEmitted: (context, previous, current) {
+        print('listener: $previous -> $current');
+        return true; // rebuild the widget
+      },
+    );
+    return Text(
+      '$counter',
+      style: Theme.of(context).textTheme.headlineMedium,
+    );
+  },
+);
 ```
 
-And also into a widget that extends a HookWidget:
+Or inside a widget that extends `HookWidget` directly:
 
 ```dart
-class BlocBuilder<B extends StateStreamable<S>, S> extends BlocWidget<B, S> {
-  const BlocBuilder({
-    Key? key,
-    this.bloc,
-    @required this.builder,
-    this.buildWhen,
-  })  : assert(builder != null),
-        super(key: key);
-
-  @override
-  final B? bloc;
-
-  @override
-  final BlocWidgetBuilder<S> builder;
-
-  @override
-  final BlocBuilderCondition<S>? buildWhen;
+class CounterText extends HookWidget {
+  const CounterText({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final state = useBloc<B, S>(
-      bloc: cubit,
-      onEmitted: (context, previous, state) {
-        return buildWhen?.call(previous, state) ?? true;
-      }
-    );
-    return builder(context, state);
+    final count = useBloc<CounterCubit, int>();
+    return Text('$count');
   }
 }
 ```
 
-And a `BlocWidget<B, S>` y defined as following:
+## Alternative to MultiBlocBuilder
 
-```dart
-abstract class BlocWidget<B extends StateStreamable<S>, S extends Object>
-    extends HookWidget {}
-```
-
-# Alternative to MultiBlocBuilder
-
-The issue with `MultiBlocBuilder` is that it could be either type safety or
-have an unliminit number of inputs (expending to much code).
-But with `useBloc` comes to the rescue.
+`flutter_bloc` has no `MultiBlocBuilder` because combining multiple
+bloc states in a type-safe way is hard. `useBloc` solves this naturally:
 
 ```dart
 class MyMultiBlocBuilder extends HookWidget {
-  const MyMultiBlocBuilder({Key? key}) : super(key: key);
+  const MyMultiBlocBuilder({super.key});
 
   @override
-  Widget build(BuildContext context){
-    // onEmitted is called every time that the state is emitter in a cubit/bloc
-    final stateA = useBloc<CubitA, int>(onEmitted: (context, previousState, state){
-      // with true, the widget rebuild, otherwise, it behave like a BlocListener
-      return buildWhenA?.call(previousState, state) ?? true;
-    });
+  Widget build(BuildContext context) {
+    // Rebuilds when CubitA emits
+    final stateA = useBloc<CubitA, int>(
+      onEmitted: (context, previous, current) => true,
+    );
 
-    final stateB = useBloc<BlocB, String>(onEmitted: (context, previousState, state){
-      // If you also want to have a BlocListener behavior, you can add some code here
-      if(listenWhen?.call(previousState, state) ?? true){
-        listener(context, state);
-      }
-      return buildWhenB?.call(previousState, state) ?? true;
-    });
+    // Rebuilds when BlocB emits, and also calls a listener
+    final stateB = useBloc<BlocB, String>(
+      onEmitted: (context, previous, current) {
+        if (current != previous) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(current)),
+          );
+        }
+        return true;
+      },
+    );
 
-    // always rebuild when cubit emits a new state
+    // Always rebuilds when CubitC emits
     final stateC = useBloc<CubitC, double>();
 
     return Column(
       children: [
-        Text('${stateAA}'),
-        Text('${statecB}'),
-        Text('${stateC}'),
+        Text('$stateA'),
+        Text('$stateB'),
+        Text('$stateC'),
       ],
     );
   }

--- a/packages/flutter_hooks_bloc/example/lib/main.dart
+++ b/packages/flutter_hooks_bloc/example/lib/main.dart
@@ -1,3 +1,4 @@
+// This is an example. There's no need to document public API
 // ignore_for_file: public_member_api_docs
 
 import 'package:flutter/material.dart';
@@ -8,11 +9,9 @@ void main() {
 }
 
 class CounterCubit extends Cubit<int> {
-  CounterCubit(super.state);
+  CounterCubit(super.initialState);
 
   void increment() => emit(state + 1);
-
-  void decrement() => emit(state - 1);
 }
 
 class MyApp extends StatelessWidget {

--- a/packages/flutter_hooks_bloc/example/pubspec.lock
+++ b/packages/flutter_hooks_bloc/example/pubspec.lock
@@ -5,58 +5,58 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.13.1"
   bloc:
     dependency: transitive
     description:
       name: bloc
-      sha256: "3820f15f502372d979121de1f6b97bfcf1630ebff8fe1d52fb2b0bfa49be5b49"
+      sha256: a48653a82055a900b88cd35f92429f068c5a8057ae9b136d197b3d56c57efb81
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.2"
+    version: "9.2.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -66,18 +66,18 @@ packages:
     dependency: transitive
     description:
       name: flutter_bloc
-      sha256: e74efb89ee6945bcbce74a5b3a5a3376b088e5f21f55c263fc38cbdc6237faae
+      sha256: cf51747952201a455a1c840f8171d273be009b932c75093020f9af64f2123e38
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.3"
+    version: "9.1.1"
   flutter_hooks:
     dependency: transitive
     description:
       name: flutter_hooks
-      sha256: "7c8db779c2d1010aa7f9ea3fbefe8f86524fcb87b69e8b0af31e1a4b55422dec"
+      sha256: "8ae1f090e5f4ef5cfa6670ce1ab5dddadd33f3533a7f9ba19d9f958aa2a89f42"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.3"
+    version: "0.21.3+1"
   flutter_hooks_bloc:
     dependency: "direct main"
     description:
@@ -94,50 +94,50 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.2"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.17.0"
   nested:
     dependency: transitive
     description:
@@ -150,87 +150,87 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   provider:
     dependency: transitive
     description:
       name: provider
-      sha256: dc18c7bddb94a1eb3c3154587d16175a657356c80566712e6cd8ca4825eae112
+      sha256: "4e82183fa20e5ca25703ead7e05de9e4cceed1fbd1eadc1ac3cb6f565a09f272"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.1"
+    version: "6.1.5+1"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.2"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.4.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.10"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "15.0.2"
 sdks:
-  dart: ">=3.2.0-0 <4.0.0"
-  flutter: ">=3.0.0"
+  dart: ">=3.9.0-0 <4.0.0"
+  flutter: ">=3.32.0"

--- a/packages/flutter_hooks_bloc/lib/flutter_hooks_bloc.dart
+++ b/packages/flutter_hooks_bloc/lib/flutter_hooks_bloc.dart
@@ -1,6 +1,6 @@
-/// A flutter_bloc implementation based on flutte_hooks,
+/// A flutter_bloc implementation based on flutter_hooks,
 /// offering better dev-tools in the widget tree
-library flutter_hooks_bloc;
+library;
 
 export 'package:flutter_hooks/flutter_hooks.dart';
 

--- a/packages/flutter_hooks_bloc/lib/src/bloc_builder.dart
+++ b/packages/flutter_hooks_bloc/lib/src/bloc_builder.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_hooks_bloc/src/bloc_hook.dart';
 import 'package:flutter_hooks_bloc/src/flutter_bloc.dart' hide BlocProvider;
@@ -30,7 +31,7 @@ typedef BlocBuilderCondition<S> = bool Function(S previous, S current);
 ///
 /// ```dart
 /// BlocBuilder<BlocA, BlocAState>(
-///   cubit: blocA,
+///   bloc: blocA,
 ///   builder: (context, state) {
 ///   // return widget here based on BlocA's state
 ///   }
@@ -61,7 +62,7 @@ typedef BlocBuilderCondition<S> = bool Function(S previous, S current);
 /// ```
 /// {@endtemplate}
 class BlocBuilder<B extends StateStreamable<S>, S> extends BlocWidget<B, S> {
-  ///The [BlocBuilder] constuctor builds a widget when a `bloc` state change.
+  /// The [BlocBuilder] constructor builds a widget when a `bloc` state changes.
   const BlocBuilder({
     required this.builder,
     super.key,
@@ -91,5 +92,19 @@ class BlocBuilder<B extends StateStreamable<S>, S> extends BlocWidget<B, S> {
   @override
   bool onStateEmitted(BuildContext context, S previous, S state) {
     return buildWhen?.call(previous, state) ?? true;
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(
+        ObjectFlagProperty<BlocBuilderCondition<S>?>.has(
+          'buildWhen',
+          buildWhen,
+        ),
+      )
+      ..add(DiagnosticsProperty<B?>('bloc', bloc))
+      ..add(ObjectFlagProperty<BlocWidgetBuilder<S>>.has('builder', builder));
   }
 }

--- a/packages/flutter_hooks_bloc/lib/src/bloc_consumer.dart
+++ b/packages/flutter_hooks_bloc/lib/src/bloc_consumer.dart
@@ -1,4 +1,5 @@
 import 'package:bloc/bloc.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import 'package:flutter_hooks_bloc/src/bloc_builder.dart';
@@ -63,7 +64,7 @@ import 'package:flutter_hooks_bloc/src/bloc_listener.dart';
 /// {@endtemplate}
 class BlocConsumer<B extends StateStreamable<S>, S extends Object>
     extends BlocListenerBase<B, S> {
-  /// The [BlocConsumer] constuctor listen and rebuilds a widget
+  /// The [BlocConsumer] constructor listens and rebuilds a widget
   /// when a `bloc` state change.
   const BlocConsumer({
     required super.listener,
@@ -79,7 +80,7 @@ class BlocConsumer<B extends StateStreamable<S>, S extends Object>
   });
 
   /// Takes the previous `state` and the current `state` and is responsible for
-  /// returning a [bool] which determines whether or not to call [listener] of
+  /// returning a [bool] which determines whether or not to rebuild
   /// [BlocConsumer] with the current `state`.
   final BlocBuilderCondition<S>? buildWhen;
 
@@ -89,9 +90,6 @@ class BlocConsumer<B extends StateStreamable<S>, S extends Object>
   /// This is analogous to the [builder] function in [StreamBuilder].
   final BlocWidgetBuilder<S> builder;
 
-  /// Takes the previous `state` and the current `state` and is responsible
-  /// for returning a [bool] which determines whether or not to trigger
-  /// [builder] with the current `state`.
   @override
   Widget build(BuildContext context) {
     final state = $use();
@@ -102,5 +100,26 @@ class BlocConsumer<B extends StateStreamable<S>, S extends Object>
   bool onStateEmitted(BuildContext context, S previous, S state) {
     super.onStateEmitted(context, previous, state);
     return buildWhen?.call(previous, state) ?? true;
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty<B?>('bloc', bloc))
+      ..add(ObjectFlagProperty<BlocWidgetBuilder<S>>.has('builder', builder))
+      ..add(ObjectFlagProperty<BlocWidgetListener<S>>.has('listener', listener))
+      ..add(
+        ObjectFlagProperty<BlocBuilderCondition<S>?>.has(
+          'buildWhen',
+          buildWhen,
+        ),
+      )
+      ..add(
+        ObjectFlagProperty<BlocListenerCondition<S>?>.has(
+          'listenWhen',
+          listenWhen,
+        ),
+      );
   }
 }

--- a/packages/flutter_hooks_bloc/lib/src/bloc_hook.dart
+++ b/packages/flutter_hooks_bloc/lib/src/bloc_hook.dart
@@ -93,6 +93,7 @@ class _BlocHook<S> extends Hook<S> {
 }
 
 class _BlocHookState<S> extends HookState<S, _BlocHook<S>> {
+  /// The cancel method is called in [_unsubscribe]
   // ignore: cancel_subscriptions
   StreamSubscription<S>? _subscription;
 
@@ -144,9 +145,10 @@ class _BlocHookState<S> extends HookState<S, _BlocHook<S>> {
   }
 
   void _unsubscribe() {
-    if (_subscription != null) {
-      _subscription!.cancel();
-      _subscription = null;
+    final subscription = _subscription;
+    _subscription = null;
+    if (subscription != null) {
+      unawaited(subscription.cancel());
     }
   }
 }

--- a/packages/flutter_hooks_bloc/lib/src/bloc_listener.dart
+++ b/packages/flutter_hooks_bloc/lib/src/bloc_listener.dart
@@ -100,6 +100,20 @@ class BlocListener<B extends StateStreamable<S>, S extends Object>
       showSeparator: bloc?.state != null,
     );
   }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty<B?>('bloc', bloc))
+      ..add(ObjectFlagProperty<BlocWidgetListener<S>>.has('listener', listener))
+      ..add(
+        ObjectFlagProperty<BlocListenerCondition<S>?>.has(
+          'listenWhen',
+          listenWhen,
+        ),
+      );
+  }
 }
 
 /// {@template bloc_listener_base}
@@ -135,7 +149,10 @@ abstract class BlocListenerBase<B extends StateStreamable<S>, S extends Object>
   @override
   Widget build(BuildContext context) {
     $use();
-    return child!;
+    return switch (child) {
+      final Widget child => child,
+      null => const Offstage(),
+    };
   }
 
   @override
@@ -144,18 +161,5 @@ abstract class BlocListenerBase<B extends StateStreamable<S>, S extends Object>
       listener.call(context, state);
     }
     return false;
-  }
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties.add(
-      DiagnosticsProperty<S>(
-        'state',
-        bloc?.state,
-        ifNull: '<null>',
-        showSeparator: bloc?.state != null,
-      ),
-    );
   }
 }

--- a/packages/flutter_hooks_bloc/lib/src/multi_bloc_listener.dart
+++ b/packages/flutter_hooks_bloc/lib/src/multi_bloc_listener.dart
@@ -45,11 +45,10 @@ import 'package:flutter_hooks_bloc/src/flutter_bloc.dart';
 /// )
 /// ```
 ///
-/// [MultiBlocListener] avoids converts a tree of nested [BlocListener] and
-/// only add a widget to the widget tree.
-/// As a result, the only advantages of using [MultiBlocListener] are both the
-/// reduce of widgets in the widget tree and better readability due to the
-/// reduction in nesting and boilerplate.
+/// [MultiBlocListener] converts a tree of nested [BlocListener] widgets into
+/// a flat list, adding only one widget to the widget tree.
+/// The advantages of using [MultiBlocListener] are fewer widgets in the widget
+/// tree and better readability due to reduced nesting and boilerplate.
 /// {@endtemplate}
 class MultiBlocListener extends HookWidget {
   /// {@macro multi_bloc_listener}
@@ -63,8 +62,8 @@ class MultiBlocListener extends HookWidget {
           'BlocListener must have no child in a MultiBlocListener',
         );
 
-  /// List of [BlocListener] and/or  [NestableBlocListener].
-  /// Must have at least one element
+  /// List of [BlocListener] and/or [NestableBlocListener].
+  /// Must have at least one element.
   final List<NestableBlocListener> listeners;
 
   /// `child` [Widget] for [MultiBlocListener]
@@ -95,21 +94,22 @@ class MultiBlocListener extends HookWidget {
 }
 
 /// The [NestableBlocListener] is the base for every item in a
-/// [MultiBlocProvider]. Thus, the bloc listener is not limited to be a
-/// [BlocListener], but can another type.
+/// [MultiBlocListener]. Thus, the bloc listener is not limited to be a
+/// [BlocListener], but can be another type.
 ///
-/// see also
+/// See also:
 /// - [MultiBlocListener]
 abstract class NestableBlocListener {
-  /// The `listen` method describe how a widget must listen a [BlocBase]
+  /// Describes how a widget must listen to a [BlocBase].
   void listen();
 
-  /// Given that the [NestableBlocListener] are used in a [MultiBlocProvider]
-  /// The must not have a child each one. Then, the `hasNoChild` allows
-  /// the [MultiBlocProvider] to check that they don't have them.
+  /// Given that [NestableBlocListener]s are used in a [MultiBlocListener],
+  /// they must not each have a child. The `hasNoChild` property allows
+  /// [MultiBlocListener] to verify this.
   bool get hasNoChild;
 
-  /// Generates a [DiagnosticsNode] for show the `bloc` states in the debugger.
+  /// Generates a [DiagnosticsNode] for showing the `bloc` state
+  /// in the debugger.
   DiagnosticsNode asDiagnosticsNode();
 }
 
@@ -118,8 +118,8 @@ extension _DebugBlocListenerWithNoChildX on List<NestableBlocListener> {
 }
 
 /// {@template bloc_listener_tree}
-/// The [BlocListenerTree] is a [DiagnosticableTree] for showwing
-/// the `bloc` providers in the devtools.
+/// The [BlocListenerTree] is a [DiagnosticableTree] for showing
+/// the `bloc` listeners in the devtools.
 /// {@endtemplate}
 @visibleForTesting
 class BlocListenerTree extends DiagnosticableTree {

--- a/packages/flutter_hooks_bloc/pubspec.lock
+++ b/packages/flutter_hooks_bloc/pubspec.lock
@@ -5,58 +5,58 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.13.1"
   bloc:
     dependency: "direct main"
     description:
       name: bloc
-      sha256: "106842ad6569f0b60297619e9e0b1885c2fb9bf84812935490e6c5275777804e"
+      sha256: a48653a82055a900b88cd35f92429f068c5a8057ae9b136d197b3d56c57efb81
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.4"
+    version: "9.2.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -66,18 +66,18 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_bloc
-      sha256: f0ecf6e6eb955193ca60af2d5ca39565a86b8a142452c5b24d96fb477428f4d2
+      sha256: cf51747952201a455a1c840f8171d273be009b932c75093020f9af64f2123e38
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.5"
+    version: "9.1.1"
   flutter_hooks:
     dependency: "direct main"
     description:
       name: flutter_hooks
-      sha256: cde36b12f7188c85286fba9b38cc5a902e7279f36dd676967106c041dc9dde70
+      sha256: "8ae1f090e5f4ef5cfa6670ce1ab5dddadd33f3533a7f9ba19d9f958aa2a89f42"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.5"
+    version: "0.21.3+1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -87,50 +87,50 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.2"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.17.0"
   nested:
     dependency: transitive
     description:
@@ -143,95 +143,95 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   provider:
     dependency: transitive
     description:
       name: provider
-      sha256: dc18c7bddb94a1eb3c3154587d16175a657356c80566712e6cd8ca4825eae112
+      sha256: "4e82183fa20e5ca25703ead7e05de9e4cceed1fbd1eadc1ac3cb6f565a09f272"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.1"
+    version: "6.1.5+1"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.2"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.4.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.10"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   very_good_analysis:
     dependency: "direct dev"
     description:
       name: very_good_analysis
-      sha256: "9ae7f3a3bd5764fb021b335ca28a34f040cd0ab6eec00a1b213b445dae58a4b8"
+      sha256: d1cb1d66a5aae2c702d68caca6c8347306d35e728fd94555fa21fa0448a972e0
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.0"
+    version: "10.2.0"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "15.0.2"
 sdks:
-  dart: ">=3.2.0-0 <4.0.0"
-  flutter: ">=3.0.0"
+  dart: ">=3.11.0 <4.0.0"
+  flutter: ">=3.32.0"

--- a/packages/flutter_hooks_bloc/pubspec.yaml
+++ b/packages/flutter_hooks_bloc/pubspec.yaml
@@ -2,23 +2,23 @@ name: flutter_hooks_bloc
 description: >-
   A flutter_bloc reimplementation based on flutter_hooks
   with the same API.
-version: 0.17.0
+version: 0.18.0
 homepage: https://github.com/kranfix/riverbloc
 
 environment:
   sdk: ">=3.2.0 <4.0.0"
 
 dependencies:
-  bloc: ^8.1.4
+  bloc: ^9.2.0
   flutter:
     sdk: flutter
-  flutter_bloc: ^8.1.5
-  flutter_hooks: ^0.20.5
+  flutter_bloc: ^9.1.1
+  flutter_hooks: ^0.21.3+1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  very_good_analysis: ^6.0.0
+  very_good_analysis: ^10.0.0
   #flutter_coverage_badge: ^0.0.1+1
 
 flutter:

--- a/packages/flutter_hooks_bloc/test/bloc_listener_test.dart
+++ b/packages/flutter_hooks_bloc/test/bloc_listener_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks_bloc/flutter_hooks_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -6,6 +8,11 @@ class CounterCubit extends Cubit<int> {
   CounterCubit() : super(0);
 
   void increment() => emit(state + 1);
+
+  @override
+  String toString() {
+    return 'CounterCubit($state)';
+  }
 }
 
 class MyApp extends StatefulWidget {
@@ -28,7 +35,7 @@ class _MyAppState extends State<MyApp> {
 
   @override
   void dispose() {
-    _counterCubit.close();
+    unawaited(_counterCubit.close());
     super.dispose();
   }
 
@@ -447,14 +454,16 @@ void main() {
 
       expect(
         blocListener.toDiagnosticsNode().toStringDeep(),
-        'BlocListener<CounterCubit, int>(state: 0)\n',
+        'BlocListener<CounterCubit, int>(bloc: CounterCubit(0),'
+        ' has listener)\n',
       );
 
       cubit.increment();
 
       expect(
         blocListener.toDiagnosticsNode().toStringDeep(),
-        'BlocListener<CounterCubit, int>(state: 1)\n',
+        'BlocListener<CounterCubit, int>(bloc: CounterCubit(1),'
+        ' has listener)\n',
       );
     });
   });

--- a/packages/flutter_hooks_bloc/test/flutter_bloc_original/bloc_builder_test.dart
+++ b/packages/flutter_hooks_bloc/test/flutter_bloc_original/bloc_builder_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks_bloc/flutter_hooks_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -5,21 +6,30 @@ import 'package:flutter_test/flutter_test.dart';
 class MyThemeApp extends StatefulWidget {
   const MyThemeApp({
     required Cubit<ThemeData> themeCubit,
-    required VoidCallback onBuild,
+    required void Function() onBuild,
     super.key,
   })  : _themeCubit = themeCubit,
         _onBuild = onBuild;
 
   final Cubit<ThemeData> _themeCubit;
-  final VoidCallback _onBuild;
+  final void Function() _onBuild;
 
   @override
   State<MyThemeApp> createState() => MyThemeAppState();
 }
 
 class MyThemeAppState extends State<MyThemeApp> {
-  late Cubit<ThemeData> _themeCubit = widget._themeCubit;
-  VoidCallback get _onBuild => widget._onBuild;
+  MyThemeAppState();
+
+  @override
+  void initState() {
+    super.initState();
+    _themeCubit = widget._themeCubit;
+    _onBuild = widget._onBuild;
+  }
+
+  late Cubit<ThemeData> _themeCubit;
+  late final void Function() _onBuild;
 
   @override
   Widget build(BuildContext context) {
@@ -43,7 +53,10 @@ class MyThemeAppState extends State<MyThemeApp> {
                 key: const Key('raised_button_2'),
                 child: const SizedBox(),
                 onPressed: () {
-                  setState(() {});
+                  // Self-assignment used to trigger setState
+                  // without changing value.
+                  // ignore: no_self_assignments
+                  setState(() => _themeCubit = _themeCubit);
                 },
               ),
             ],
@@ -64,12 +77,12 @@ class ThemeCubit extends Cubit<ThemeData> {
 class DarkThemeCubit extends Cubit<ThemeData> {
   DarkThemeCubit() : super(ThemeData.dark());
 
-  void setDarkTheme() => emit(ThemeData.dark());
   void setLightTheme() => emit(ThemeData.light());
 }
 
 class MyCounterApp extends StatefulWidget {
   const MyCounterApp({super.key});
+
   @override
   State<StatefulWidget> createState() => MyCounterAppState();
 }
@@ -118,10 +131,9 @@ class MyCounterAppState extends State<MyCounterApp> {
 }
 
 class CounterCubit extends Cubit<int> {
-  CounterCubit() : super(0);
+  CounterCubit({int seed = 0}) : super(seed);
 
   void increment() => emit(state + 1);
-  void decrement() => emit(state - 1);
 }
 
 void main() {
@@ -466,7 +478,7 @@ void main() {
 
     testWidgets('rebuilds when provided bloc is changed', (tester) async {
       final firstCounterCubit = CounterCubit();
-      final secondCounterCubit = CounterCubit()..emit(100);
+      final secondCounterCubit = CounterCubit(seed: 100);
 
       await tester.pumpWidget(
         Directionality(
@@ -506,6 +518,30 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Count 101'), findsOneWidget);
+    });
+
+    testWidgets('overrides debugFillProperties', (tester) async {
+      final builder = DiagnosticPropertiesBuilder();
+
+      BlocBuilder(
+        bloc: CounterCubit(),
+        builder: (context, state) => const SizedBox(),
+        buildWhen: (previous, current) => previous != current,
+      ).debugFillProperties(builder);
+
+      final description = builder.properties
+          .where((node) => !node.isFiltered(DiagnosticLevel.info))
+          .map((node) => node.toString())
+          .toList();
+
+      expect(
+        description,
+        <String>[
+          'has buildWhen',
+          "bloc: Instance of 'CounterCubit'",
+          'has builder',
+        ],
+      );
     });
   });
 }

--- a/packages/flutter_hooks_bloc/test/flutter_bloc_original/bloc_consumer_test.dart
+++ b/packages/flutter_hooks_bloc/test/flutter_bloc_original/bloc_consumer_test.dart
@@ -1,9 +1,12 @@
+// This file uses a non-conventional naming to match flutter_bloc test files.
+// ignore_for_file: prefer_file_naming_conventions
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks_bloc/flutter_hooks_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class CounterCubit extends Cubit<int> {
-  CounterCubit() : super(0);
+  CounterCubit({int seed = 0}) : super(seed);
 
   void increment() => emit(state + 1);
 }
@@ -351,7 +354,7 @@ void main() {
         'rebuilds and updates subscription '
         'when provided bloc is changed', (tester) async {
       final firstCounterCubit = CounterCubit();
-      final secondCounterCubit = CounterCubit()..emit(100);
+      final secondCounterCubit = CounterCubit(seed: 100);
 
       final states = <int>[];
       const expectedStates = [1, 101];
@@ -398,6 +401,34 @@ void main() {
 
       expect(find.text('Count 101'), findsOneWidget);
       expect(states, expectedStates);
+    });
+
+    testWidgets('overrides debugFillProperties', (tester) async {
+      final builder = DiagnosticPropertiesBuilder();
+
+      BlocConsumer(
+        bloc: CounterCubit(),
+        buildWhen: (previous, current) => previous != current,
+        builder: (context, state) => const SizedBox(),
+        listener: (context, state) {},
+        listenWhen: (previous, current) => previous != current,
+      ).debugFillProperties(builder);
+
+      final description = builder.properties
+          .where((node) => !node.isFiltered(DiagnosticLevel.info))
+          .map((node) => node.toString())
+          .toList();
+
+      expect(
+        description,
+        <String>[
+          "bloc: Instance of 'CounterCubit'",
+          'has builder',
+          'has listener',
+          'has buildWhen',
+          'has listenWhen',
+        ],
+      );
     });
   });
 }

--- a/packages/flutter_hooks_bloc/test/flutter_bloc_original/bloc_listener_test.dart
+++ b/packages/flutter_hooks_bloc/test/flutter_bloc_original/bloc_listener_test.dart
@@ -1,9 +1,14 @@
+// This file uses a non-conventional naming to match flutter_bloc test files.
+// ignore_for_file: prefer_file_naming_conventions
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks_bloc/flutter_hooks_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class CounterCubit extends Cubit<int> {
-  CounterCubit() : super(0);
+  CounterCubit({int seed = 0}) : super(seed);
 
   void increment() => emit(state + 1);
 }
@@ -28,7 +33,7 @@ class _MyAppState extends State<MyApp> {
 
   @override
   void dispose() {
-    _counterCubit.close();
+    unawaited(_counterCubit.close());
     super.dispose();
   }
 
@@ -54,7 +59,10 @@ class _MyAppState extends State<MyApp> {
                 key: const Key('cubit_listener_noop_button'),
                 child: const SizedBox(),
                 onPressed: () {
-                  setState(() {});
+                  // Self-assignment used to trigger setState
+                  // without changing value.
+                  // ignore: no_self_assignments
+                  setState(() => _counterCubit = _counterCubit);
                 },
               ),
               ElevatedButton(
@@ -72,7 +80,17 @@ class _MyAppState extends State<MyApp> {
 
 void main() {
   group('BlocListener', () {
-    testWidgets('renders child properly', (tester) async {
+    testWidgets('does nothing when child is not specified', (tester) async {
+      await tester.pumpWidget(
+        BlocListener<CounterCubit, int>(
+          bloc: CounterCubit(),
+          listener: (context, state) {},
+        ),
+      );
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('renders child when specified', (tester) async {
       const targetKey = Key('cubit_listener_container');
       await tester.pumpWidget(
         BlocListener<CounterCubit, int>(
@@ -91,10 +109,7 @@ void main() {
       await tester.pumpWidget(
         BlocListener<CounterCubit, int>(
           bloc: counterCubit,
-          listener: (_, state) {
-            states.add(state);
-          },
-          child: const SizedBox(),
+          listener: (_, state) => states.add(state),
         ),
       );
       counterCubit.increment();
@@ -109,10 +124,7 @@ void main() {
       await tester.pumpWidget(
         BlocListener<CounterCubit, int>(
           bloc: counterCubit,
-          listener: (_, state) {
-            states.add(state);
-          },
-          child: const SizedBox(),
+          listener: (_, state) => states.add(state),
         ),
       );
       counterCubit.increment();
@@ -216,7 +228,6 @@ void main() {
             return true;
           },
           listener: (_, __) {},
-          child: const SizedBox(),
         ),
       );
       counterCubit.increment();
@@ -248,7 +259,6 @@ void main() {
             return false;
           },
           listener: (_, __) {},
-          child: const SizedBox(),
         ),
       );
       counterCubit
@@ -280,7 +290,6 @@ void main() {
             return false;
           },
           listener: (_, state) => states.add(state),
-          child: const SizedBox(),
         ),
       );
       counterCubit
@@ -313,7 +322,6 @@ void main() {
               return true;
             },
             listener: (context, state) {},
-            child: const SizedBox(),
           ),
         ),
       );
@@ -343,7 +351,6 @@ void main() {
             return true;
           },
           listener: (_, __) {},
-          child: const SizedBox(),
         ),
       );
       await tester.pump();
@@ -368,7 +375,6 @@ void main() {
           bloc: counterCubit,
           listenWhen: (_, __) => false,
           listener: (_, state) => states.add(state),
-          child: const SizedBox(),
         ),
       );
       counterCubit.increment();
@@ -388,7 +394,6 @@ void main() {
           bloc: counterCubit,
           listenWhen: (_, __) => true,
           listener: (_, state) => states.add(state),
-          child: const SizedBox(),
         ),
       );
       counterCubit.increment();
@@ -408,7 +413,6 @@ void main() {
           bloc: counterCubit,
           listenWhen: (_, __) => false,
           listener: (_, state) => states.add(state),
-          child: const SizedBox(),
         ),
       );
       counterCubit.increment();
@@ -434,7 +438,6 @@ void main() {
           bloc: counterCubit,
           listenWhen: (_, __) => true,
           listener: (_, state) => states.add(state),
-          child: const SizedBox(),
         ),
       );
       counterCubit.increment();
@@ -453,7 +456,7 @@ void main() {
         'updates subscription '
         'when provided bloc is changed', (tester) async {
       final firstCounterCubit = CounterCubit();
-      final secondCounterCubit = CounterCubit()..emit(100);
+      final secondCounterCubit = CounterCubit(seed: 100);
 
       final states = <int>[];
       const expectedStates = [1, 101];
@@ -463,7 +466,6 @@ void main() {
           value: firstCounterCubit,
           child: BlocListener<CounterCubit, int>(
             listener: (_, state) => states.add(state),
-            child: const SizedBox(),
           ),
         ),
       );
@@ -475,7 +477,6 @@ void main() {
           value: secondCounterCubit,
           child: BlocListener<CounterCubit, int>(
             listener: (_, state) => states.add(state),
-            child: const SizedBox(),
           ),
         ),
       );
@@ -486,6 +487,30 @@ void main() {
       await tester.pump();
 
       expect(states, expectedStates);
+    });
+
+    testWidgets('overrides debugFillProperties', (tester) async {
+      final builder = DiagnosticPropertiesBuilder();
+
+      BlocListener(
+        bloc: CounterCubit(),
+        listener: (context, state) {},
+        listenWhen: (previous, current) => previous != current,
+      ).debugFillProperties(builder);
+
+      final description = builder.properties
+          .where((node) => !node.isFiltered(DiagnosticLevel.info))
+          .map((node) => node.toString())
+          .toList();
+
+      expect(
+        description,
+        <String>[
+          "bloc: Instance of 'CounterCubit'",
+          'has listener',
+          'has listenWhen',
+        ],
+      );
     });
   });
 }

--- a/packages/flutter_hooks_bloc/test/flutter_bloc_original/bloc_provider_test.dart
+++ b/packages/flutter_hooks_bloc/test/flutter_bloc_original/bloc_provider_test.dart
@@ -1,24 +1,17 @@
+// This file uses a non-conventional naming to match flutter_bloc test files.
+// ignore_for_file: prefer_file_naming_conventions
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks_bloc/flutter_hooks_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class MockCubit<S> extends Cubit<S> {
-  MockCubit(super.state);
+  MockCubit(super.initialState);
 
-  // @override
-  // StreamSubscription<S> listen(
-  //   void Function(S p1)? onData, {
-  //   Function? onError,
-  //   VoidCallback? onDone,
-  //   bool? cancelOnError,
-  // }) {
-  //   return Stream<S>.empty().listen(
-  //     onData,
-  //     onError: onError,
-  //     onDone: onDone,
-  //     cancelOnError: cancelOnError,
-  //   );
-  // }
+  @override
+  Stream<S> get stream => Stream<S>.empty();
 }
 
 class MyApp extends StatelessWidget {
@@ -101,22 +94,22 @@ class _MyStatefulAppState extends State<MyStatefulApp> {
 
   @override
   void dispose() {
-    cubit.close();
+    unawaited(cubit.close());
     super.dispose();
   }
 }
 
 class MyAppNoProvider extends MaterialApp {
   const MyAppNoProvider({
-    required Widget super.home,
+    required Widget home,
     super.key,
-  });
+  }) : super(home: home);
 }
 
 class CounterPage extends StatelessWidget {
   const CounterPage({super.key, this.onBuild});
 
-  final VoidCallback? onBuild;
+  final void Function()? onBuild;
 
   @override
   Widget build(BuildContext context) {
@@ -146,9 +139,11 @@ class RoutePage extends StatelessWidget {
             key: const Key('route_button'),
             child: const SizedBox(),
             onPressed: () {
-              Navigator.of(context).pushReplacement(
-                MaterialPageRoute<Widget>(
-                  builder: (context) => const SizedBox(),
+              unawaited(
+                Navigator.of(context).pushReplacement(
+                  MaterialPageRoute<Widget>(
+                    builder: (context) => const SizedBox(),
+                  ),
                 ),
               );
             },
@@ -167,34 +162,62 @@ class RoutePage extends StatelessWidget {
 }
 
 class CounterCubit extends Cubit<int> {
-  CounterCubit({this.onClose}) : super(0);
+  CounterCubit({VoidCallback? onClose})
+      : _onClose = onClose,
+        super(0);
 
-  final VoidCallback? onClose;
+  final VoidCallback? _onClose;
 
   void increment() => emit(state + 1);
   void decrement() => emit(state - 1);
 
   @override
   Future<void> close() {
-    onClose?.call();
+    _onClose?.call();
     return super.close();
   }
 }
 
 void main() {
   group('BlocProvider', () {
-    testWidgets('lazily loads cubits by default', (tester) async {
-      var createCalled = false;
-      await tester.pumpWidget(
-        BlocProvider(
-          create: (_) {
-            createCalled = true;
-            return CounterCubit();
-          },
-          child: const SizedBox(),
-        ),
+    testWidgets(
+        'throws AssertionError '
+        'when child is not specified', (tester) async {
+      const expected =
+          '''BlocProvider<CounterCubit> used outside of MultiBlocProvider must specify a child''';
+      await tester.pumpWidget(BlocProvider(create: (_) => CounterCubit()));
+      expect(
+        tester.takeException(),
+        isA<AssertionError>().having((e) => e.message, 'message', expected),
       );
-      expect(createCalled, isFalse);
+    });
+
+    testWidgets(
+        '.value throws AssertionError '
+        'when child is not specified', (tester) async {
+      const expected =
+          '''BlocProvider<CounterCubit> used outside of MultiBlocProvider must specify a child''';
+      await tester.pumpWidget(BlocProvider.value(value: CounterCubit()));
+      expect(
+        tester.takeException(),
+        isA<AssertionError>().having((e) => e.message, 'message', expected),
+      );
+    });
+
+    testWidgets('lazy is true by default', (tester) async {
+      final blocProvider = BlocProvider(
+        create: (_) => CounterCubit(),
+        child: const SizedBox(),
+      );
+      expect(blocProvider.lazy, isTrue);
+    });
+
+    testWidgets('.value lazy is true', (tester) async {
+      final blocProvider = BlocProvider.value(
+        value: CounterCubit(),
+        child: const SizedBox(),
+      );
+      expect(blocProvider.lazy, isTrue);
     });
 
     testWidgets('lazily loads cubits by default', (tester) async {
@@ -393,7 +416,8 @@ void main() {
     testWidgets('does not close when created using value', (tester) async {
       var closeCalled = false;
       final value = CounterCubit(onClose: () => closeCalled = true);
-      await tester.pumpWidget(MyApp(value: value, child: const RoutePage()));
+      const child = RoutePage();
+      await tester.pumpWidget(MyApp(value: value, child: child));
 
       final routeButtonFinder = find.byKey(const Key('route_button'));
       expect(routeButtonFinder, findsOneWidget);
@@ -418,7 +442,6 @@ void main() {
 
         The context used was: CounterPage(dirty)
 ''';
-      expect(exception is FlutterError, true);
       expect((exception as FlutterError).message, expectedMessage);
     });
 
@@ -438,7 +461,7 @@ void main() {
           child: const SizedBox(),
         ),
       );
-
+      FlutterError.onError = onError;
       expect(
         flutterErrors,
         contains(
@@ -448,13 +471,11 @@ void main() {
             isA<StateError>().having(
               (e) => e.message,
               'message',
-              expected,
+              contains(expected),
             ),
           ),
         ),
       );
-
-      FlutterError.onError = onError;
     });
 
     testWidgets(
@@ -476,27 +497,32 @@ void main() {
           child: const SizedBox(),
         ),
       );
-
+      FlutterError.onError = onError;
       expect(
         flutterErrors,
         contains(
           isA<FlutterErrorDetails>().having(
             (d) => d.exception,
             'exception',
-            isA<StateError>().having((e) => e.message, 'message', expected),
+            isA<StateError>().having(
+              (e) => e.message,
+              'message',
+              contains(expected),
+            ),
           ),
         ),
       );
-
-      FlutterError.onError = onError;
     });
 
     testWidgets(
         'should not rebuild widgets that inherited the cubit if the cubit is '
         'changed', (tester) async {
       var numBuilds = 0;
+      final child = CounterPage(onBuild: () => numBuilds++);
       await tester.pumpWidget(
-        MyStatefulApp(child: CounterPage(onBuild: () => numBuilds++)),
+        MyStatefulApp(
+          child: child,
+        ),
       );
       await tester.tap(find.byKey(const Key('iconButtonKey')));
       await tester.pump();
@@ -646,8 +672,8 @@ void main() {
                   body: Builder(
                     builder: (context) {
                       textBuildCount++;
-                      final isPositive = context.select(
-                        (CounterCubit c) => c.state >= 0,
+                      final isPositive = context.select<CounterCubit, bool>(
+                        (c) => c.state >= 0,
                       );
                       return Text('$isPositive', key: textKey);
                     },
@@ -706,6 +732,22 @@ void main() {
         ),
       );
       expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('overrides debugFillProperties', (tester) async {
+      final builder = DiagnosticPropertiesBuilder();
+
+      BlocProvider(
+        create: (context) => CounterCubit(),
+        child: const SizedBox(),
+      ).debugFillProperties(builder);
+
+      final description = builder.properties
+          .where((node) => !node.isFiltered(DiagnosticLevel.info))
+          .map((node) => node.toString())
+          .toList();
+
+      expect(description, <String>['lazy: true']);
     });
   });
 }

--- a/packages/flutter_hooks_bloc/test/flutter_bloc_original/bloc_selector_test.dart
+++ b/packages/flutter_hooks_bloc/test/flutter_bloc_original/bloc_selector_test.dart
@@ -1,9 +1,12 @@
+// This file uses a non-conventional naming to match flutter_bloc test files.
+// ignore_for_file: prefer_file_naming_conventions
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks_bloc/flutter_hooks_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class CounterCubit extends Cubit<int> {
-  CounterCubit() : super(0);
+  CounterCubit({int seed = 0}) : super(seed);
 
   void increment() => emit(state + 1);
 }
@@ -95,7 +98,7 @@ void main() {
 
     testWidgets('rebuilds when provided bloc is changed', (tester) async {
       final firstCounterCubit = CounterCubit();
-      final secondCounterCubit = CounterCubit()..emit(100);
+      final secondCounterCubit = CounterCubit(seed: 100);
 
       await tester.pumpWidget(
         Directionality(
@@ -142,7 +145,7 @@ void main() {
 
     testWidgets('rebuilds when bloc is changed at runtime', (tester) async {
       final firstCounterCubit = CounterCubit();
-      final secondCounterCubit = CounterCubit()..emit(100);
+      final secondCounterCubit = CounterCubit(seed: 100);
 
       await tester.pumpWidget(
         Directionality(
@@ -181,6 +184,62 @@ void main() {
 
       expect(find.text('isEven: false'), findsOneWidget);
       expect(find.text('isEven: true'), findsNothing);
+    });
+
+    testWidgets('rebuilds when selector changes', (tester) async {
+      final counterCubit = CounterCubit();
+      var selector = (int state) => state.isEven;
+
+      Widget buildWidget() {
+        return Directionality(
+          textDirection: TextDirection.ltr,
+          child: BlocSelector<CounterCubit, int, bool>(
+            bloc: counterCubit,
+            selector: selector,
+            builder: (context, state) => Text('Selected: $state'),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(buildWidget());
+      expect(find.text('Selected: true'), findsOneWidget);
+
+      counterCubit.increment();
+      await tester.pumpAndSettle();
+      expect(find.text('Selected: false'), findsOneWidget);
+
+      selector = (state) => state.isOdd;
+
+      await tester.pumpWidget(buildWidget());
+      expect(find.text('Selected: true'), findsOneWidget);
+
+      counterCubit.increment();
+      await tester.pumpAndSettle();
+      expect(find.text('Selected: false'), findsOneWidget);
+    });
+
+    testWidgets('overrides debugFillProperties', (tester) async {
+      final builder = DiagnosticPropertiesBuilder();
+
+      BlocSelector(
+        bloc: CounterCubit(),
+        builder: (context, state) => const SizedBox(),
+        selector: (state) => state,
+      ).debugFillProperties(builder);
+
+      final description = builder.properties
+          .where((node) => !node.isFiltered(DiagnosticLevel.info))
+          .map((node) => node.toString())
+          .toList();
+
+      expect(
+        description,
+        <String>[
+          "bloc: Instance of 'CounterCubit'",
+          'has builder',
+          'has selector',
+        ],
+      );
     });
   });
 }

--- a/packages/flutter_hooks_bloc/test/flutter_bloc_original/multi_bloc_listener_test.dart
+++ b/packages/flutter_hooks_bloc/test/flutter_bloc_original/multi_bloc_listener_test.dart
@@ -1,3 +1,5 @@
+// This file uses a non-conventional naming to match flutter_bloc test files.
+// ignore_for_file: prefer_file_naming_conventions
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks_bloc/flutter_hooks_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -62,13 +64,13 @@ void main() {
       await tester.pumpWidget(
         MultiBlocListener(
           listeners: [
-            BlocListener(
+            BlocListener<CounterCubit, int>(
               bloc: counterCubitA,
-              listener: (BuildContext context, int state) => statesA.add(state),
+              listener: (context, state) => statesA.add(state),
             ),
-            BlocListener(
+            BlocListener<CounterCubit, int>(
               bloc: counterCubitB,
-              listener: (BuildContext context, int state) => statesB.add(state),
+              listener: (context, state) => statesB.add(state),
             ),
           ],
           child: const SizedBox(key: Key('multiCubitListener_child')),

--- a/packages/flutter_hooks_bloc/test/flutter_bloc_original/multi_bloc_provider_test.dart
+++ b/packages/flutter_hooks_bloc/test/flutter_bloc_original/multi_bloc_provider_test.dart
@@ -1,3 +1,7 @@
+// This file uses a non-conventional naming to match flutter_bloc test files.
+// ignore_for_file: prefer_file_naming_conventions
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks_bloc/flutter_hooks_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -23,25 +27,40 @@ class HomePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MultiBlocProvider(
-      providers: [
-        if (counterCubitValue != null)
+    List<BlocProvider<StateStreamableSource<Object?>>> getProviders() {
+      final providers = <BlocProvider>[];
+      if (counterCubitValue != null) {
+        providers.add(
           BlocProvider<CounterCubit>.value(
             value: counterCubitValue!,
-          )
-        else
+          ),
+        );
+      } else {
+        providers.add(
           BlocProvider<CounterCubit>(
             create: (_) => CounterCubit(onClose: onCounterCubitClosed),
           ),
-        if (themeCubitValue != null)
+        );
+      }
+
+      if (themeCubitValue != null) {
+        providers.add(
           BlocProvider<ThemeCubit>.value(
             value: themeCubitValue!,
-          )
-        else
+          ),
+        );
+      } else {
+        providers.add(
           BlocProvider<ThemeCubit>(
             create: (_) => ThemeCubit(onClose: onThemeCubitClosed),
           ),
-      ],
+        );
+      }
+      return providers;
+    }
+
+    return MultiBlocProvider(
+      providers: getProviders(),
       child: Builder(
         builder: (context) {
           return Column(
@@ -50,8 +69,12 @@ class HomePage extends StatelessWidget {
                 key: const Key('pop_button'),
                 child: const SizedBox(),
                 onPressed: () {
-                  Navigator.of(context).pushReplacement(
-                    MaterialPageRoute<void>(builder: (_) => const SizedBox()),
+                  unawaited(
+                    Navigator.of(context).pushReplacement(
+                      MaterialPageRoute<void>(
+                        builder: (_) => const SizedBox(),
+                      ),
+                    ),
                   );
                 },
               ),
@@ -76,6 +99,7 @@ class HomePage extends StatelessWidget {
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
+
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<ThemeCubit, ThemeData>(
@@ -89,6 +113,7 @@ class MyApp extends StatelessWidget {
 
 class CounterPage extends StatelessWidget {
   const CounterPage({super.key});
+
   @override
   Widget build(BuildContext context) {
     final counterCubit = BlocProvider.of<CounterCubit>(context);
@@ -111,24 +136,28 @@ class CounterPage extends StatelessWidget {
 }
 
 class CounterCubit extends Cubit<int> {
-  CounterCubit({this.onClose}) : super(0);
+  CounterCubit({VoidCallback? onClose})
+      : _onClose = onClose,
+        super(0);
 
-  final VoidCallback? onClose;
+  final VoidCallback? _onClose;
 
   void increment() => emit(state + 1);
   void decrement() => emit(state - 1);
 
   @override
   Future<void> close() {
-    onClose?.call();
+    _onClose?.call();
     return super.close();
   }
 }
 
 class ThemeCubit extends Cubit<ThemeData> {
-  ThemeCubit({this.onClose}) : super(ThemeData.light());
+  ThemeCubit({VoidCallback? onClose})
+      : _onClose = onClose,
+        super(ThemeData.light());
 
-  final VoidCallback? onClose;
+  final VoidCallback? _onClose;
 
   void toggle() {
     emit(state == ThemeData.dark() ? ThemeData.light() : ThemeData.dark());
@@ -136,7 +165,7 @@ class ThemeCubit extends Cubit<ThemeData> {
 
   @override
   Future<void> close() {
-    onClose?.call();
+    _onClose?.call();
     return super.close();
   }
 }

--- a/packages/flutter_hooks_bloc/test/flutter_bloc_original/multi_repository_provider_test.dart
+++ b/packages/flutter_hooks_bloc/test/flutter_bloc_original/multi_repository_provider_test.dart
@@ -8,6 +8,7 @@ class MyApp extends MaterialApp {
 
 class CounterPage extends StatelessWidget {
   const CounterPage({super.key});
+
   @override
   Widget build(BuildContext context) {
     final repositoryA = RepositoryProvider.of<RepositoryA>(context);

--- a/packages/flutter_hooks_bloc/test/flutter_bloc_original/repository_provider_test.dart
+++ b/packages/flutter_hooks_bloc/test/flutter_bloc_original/repository_provider_test.dart
@@ -16,7 +16,7 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (useValueProvider == true) {
+    if (useValueProvider) {
       return MaterialApp(
         home: RepositoryProvider<Repository>.value(
           value: repository,
@@ -96,24 +96,6 @@ class CounterPage extends StatelessWidget {
   }
 }
 
-class RoutePage extends StatelessWidget {
-  const RoutePage({super.key});
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      body: ElevatedButton(
-        key: const Key('route_button'),
-        child: const SizedBox(),
-        onPressed: () {
-          Navigator.of(context).pushReplacement(
-            MaterialPageRoute<Widget>(builder: (context) => const SizedBox()),
-          );
-        },
-      ),
-    );
-  }
-}
-
 class Repository {
   const Repository(this.data);
 
@@ -158,11 +140,11 @@ void main() {
         const MyApp(repository: repository, child: child),
       );
 
-      final counterFinder1 = find.byKey(const Key('value_data'));
-      expect(counterFinder1, findsOneWidget);
+      final counterFinder = find.byKey(const Key('value_data'));
+      expect(counterFinder, findsOneWidget);
 
-      final counterText1 = counterFinder1.evaluate().first.widget as Text;
-      expect(counterText1.data, '0');
+      final counterText = counterFinder.evaluate().first.widget as Text;
+      expect(counterText.data, '0');
     });
 
     testWidgets('passes value to children via value', (tester) async {
@@ -176,11 +158,11 @@ void main() {
         ),
       );
 
-      final counterFinder0 = find.byKey(const Key('value_data'));
-      expect(counterFinder0, findsOneWidget);
+      final counterFinder = find.byKey(const Key('value_data'));
+      expect(counterFinder, findsOneWidget);
 
-      final counterText0 = counterFinder0.evaluate().first.widget as Text;
-      expect(counterText0.data, '0');
+      final counterText = counterFinder.evaluate().first.widget as Text;
+      expect(counterText.data, '0');
     });
 
     testWidgets(
@@ -197,7 +179,6 @@ void main() {
 
         The context used was: CounterPage(dirty)
 ''';
-      expect(exception is FlutterError, true);
       expect((exception as FlutterError).message, expectedMessage);
     });
 
@@ -217,7 +198,7 @@ void main() {
           child: const SizedBox(),
         ),
       );
-
+      FlutterError.onError = onError;
       expect(
         flutterErrors,
         contains(
@@ -227,13 +208,11 @@ void main() {
             isA<StateError>().having(
               (e) => e.message,
               'message',
-              expected,
+              contains(expected),
             ),
           ),
         ),
       );
-
-      FlutterError.onError = onError;
     });
 
     testWidgets(
@@ -255,19 +234,21 @@ void main() {
           child: const SizedBox(),
         ),
       );
-
+      FlutterError.onError = onError;
       expect(
         flutterErrors,
         contains(
           isA<FlutterErrorDetails>().having(
             (d) => d.exception,
             'exception',
-            isA<StateError>().having((e) => e.message, 'message', expected),
+            isA<StateError>().having(
+              (e) => e.message,
+              'message',
+              contains(expected),
+            ),
           ),
         ),
       );
-
-      FlutterError.onError = onError;
     });
 
     testWidgets(
@@ -374,6 +355,48 @@ void main() {
 
       final counterText = counterFinder.evaluate().first.widget as Text;
       expect(counterText.data, '0');
+    });
+
+    testWidgets('calls dispose callback when disposed', (tester) async {
+      var disposeCalled = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: RepositoryProvider<Repository>(
+              create: (_) => const Repository(0),
+              dispose: (repository) {
+                disposeCalled = true;
+                expect(repository.data, equals(0));
+              },
+              child: Builder(
+                builder: (context) => Text(
+                  '${context.read<Repository>().data}',
+                  key: const Key('value_data'),
+                ),
+              ),
+            ),
+            floatingActionButton: Builder(
+              builder: (context) => FloatingActionButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Icon(Icons.remove),
+              ),
+            ),
+          ),
+        ),
+      );
+      final repositoryFinder = find.byKey(const Key('value_data'));
+      expect(repositoryFinder, findsOneWidget);
+
+      final repositoryText = repositoryFinder.evaluate().first.widget as Text;
+      expect(repositoryText.data, '0');
+
+      final fabFinder = find.byType(FloatingActionButton);
+      expect(fabFinder, findsOneWidget);
+
+      expect(disposeCalled, isFalse);
+      await tester.tap(fabFinder);
+      await tester.pumpAndSettle();
+      expect(disposeCalled, isTrue);
     });
   });
 }

--- a/packages/flutter_hooks_bloc/test/multi_bloc_listener_test.dart
+++ b/packages/flutter_hooks_bloc/test/multi_bloc_listener_test.dart
@@ -5,8 +5,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 class CounterCubit extends Cubit<int> {
   CounterCubit() : super(0);
-
-  void increment() => emit(state + 1);
 }
 
 mixin _DecrementerMixin on CounterCubit {
@@ -26,7 +24,7 @@ void main() {
             child: const SizedBox(),
           ),
         );
-      } catch (error) {
+      } on Object catch (error) {
         expect(error, isAssertionError);
       }
     });
@@ -38,9 +36,9 @@ void main() {
         await tester.pumpWidget(
           MultiBlocListener(
             listeners: [
-              BlocListener(
+              BlocListener<CounterCubit, int>(
                 bloc: counterCubit,
-                listener: (BuildContext context, int state) {},
+                listener: (context, state) {},
                 child: const SizedBox(),
               ),
             ],
@@ -48,7 +46,7 @@ void main() {
           ),
         );
         fail('should throw AssertionError');
-      } catch (error) {
+      } on Object catch (error) {
         expect(error, isAssertionError);
       }
     });

--- a/packages/flutter_hooks_bloc/test/use_bloc_test.dart
+++ b/packages/flutter_hooks_bloc/test/use_bloc_test.dart
@@ -3,11 +3,9 @@ import 'package:flutter_hooks_bloc/flutter_hooks_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class CounterCubit extends Cubit<int> {
-  CounterCubit(super.state);
+  CounterCubit(super.initialState);
 
   void increment() => emit(state + 1);
-
-  void decrement() => emit(state - 1);
 }
 
 class MyApp extends StatelessWidget {


### PR DESCRIPTION
- Upgrade dependencies: bloc ^9.2.0, flutter_bloc ^9.1.1, flutter_hooks ^0.21.3+1
- Fix: BlocListener with no child renders Offstage instead of crashing
- Add debugFillProperties to BlocBuilder, BlocListener and BlocConsumer
- Fix: _BlocHookState._unsubscribe uses unawaited pattern
- Lint fixes across the test suite
- Update README and fix dartdoc comments
- Fix CHANGELOG dates